### PR TITLE
feat(5): added config test

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -70,6 +70,8 @@ linters-settings:
   gomnd:
     ignored-functions:
       - "os.FileMode"
+      - "os.Mkdir"
+      - "file.Chmod"
 
   govet:
     check-shadowing: true

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,75 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const testConfigFilename = "config.json" // can't use other names
+var supportedOS = []string{"windows", "linux", "darwin"}
+
+var (
+	workDirectory, _ = os.Getwd()
+	testDirectory    = filepath.Join(workDirectory, "tests")
+	configFilePath   = filepath.Join(testDirectory, testConfigFilename)
+)
+
+// [TestExists]: Just testing if the helper function works properly.
+func TestExists(t *testing.T) {
+	os.Mkdir(testDirectory, 0o644)
+	assert.True(t, exists(testDirectory))
+	os.Remove(testDirectory)
+	assert.False(t, exists(testDirectory))
+}
+
+// [testConfigContent]: Helper Function that checks the conf.
+func testConfigContent(t *testing.T, conf *Config) {
+	assert.NotNil(t, conf)
+	assert.Contains(t, supportedOS, conf.OS)
+	assert.NotEmpty(t, conf.Name)
+	assert.True(t, exists(configFilePath)) // uses a global var
+}
+
+// TestCase: Everything all right.
+func TestCase_EverythingGood(t *testing.T) {
+	// check for test config existence
+	if exists(configFilePath) {
+		os.Remove(configFilePath)
+	}
+
+	// first test, creating the new cfg and storing in file
+	cfg_new, err := Load(configFilePath)
+	assert.NoError(t, err)
+	testConfigContent(t, cfg_new)
+
+	// second test, loading the cfg from file
+	cfg_loaded, err := Load(configFilePath)
+	assert.NoError(t, err)
+	testConfigContent(t, cfg_loaded)
+
+	os.Remove(configFilePath)
+}
+
+// TestCase: Function is provided with an inaccesible path.
+func TestCase_WrongFolder_ExpectedError(t *testing.T) {
+	wrongDirectory := "A://bcdefg/"
+	wrongFilePath := filepath.Join(wrongDirectory, testConfigFilename)
+	_, err := Load(wrongFilePath)
+	assert.Error(t, err)
+}
+
+// TestCase: Function tries to load cfg from a file that is not Json at all.
+func TestCase_UnreadableJson_ExpectedError(t *testing.T) {
+	data := []byte("test")
+	file, _ := os.Create(configFilePath)
+	file.Write(data)
+	file.Close()
+
+	_, err := Load(configFilePath)
+	assert.Error(t, err)
+
+	os.Remove(configFilePath)
+}

--- a/go.mod
+++ b/go.mod
@@ -6,15 +6,19 @@ require github.com/rs/zerolog v1.29.1
 
 require (
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
+	github.com/stretchr/testify v1.8.4
 	golang.org/x/oauth2 v0.7.0
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.17 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/net v0.9.0 // indirect
 	golang.org/x/sys v0.7.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.28.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
@@ -16,9 +18,13 @@ github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/
 github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 h1:KoWmjvw+nsYOo29YJK9vDA65RGE3NrOnUtO7a+RF9HU=
 github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8/go.mod h1:HKlIX3XHQyzLZPlr7++PzdhaXEj94dEiJgZDTsxEqUI=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.29.1 h1:cO+d60CHkknCbvzEWxP0S9K6KqyTjrCNUy1LdQLCGPc=
 github.com/rs/zerolog v1.29.1/go.mod h1:Le6ESbR7hc+DP6Lt1THiV8CQSdkkNrd3R0XbEgp3ZBU=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.9.0 h1:aWJ/m6xSmxWBx+V0XRHTlrYrPG56jKsLdTFmsSsCzOM=
@@ -42,3 +48,7 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.28.0 h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscLw=
 google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -18,13 +18,22 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-func main() {
-	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: time.DateTime})
+const (
+	projectFolderName = "anio"
+)
 
+func main() {
 	ctx := context.Background()
 
+	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: time.DateTime})
+
 	log.Info().Msg("loading config...")
-	cfg, err := config.Load()
+	cfgFilePath, err := config.GetConfigFilePath(projectFolderName)
+	if err != nil {
+		log.Fatal().Err(err).Msg("couldn't get config file path")
+	}
+
+	cfg, err := config.Load(cfgFilePath)
 	if err != nil {
 		log.Fatal().Err(err).Msg("couldn't load config")
 	}


### PR DESCRIPTION
There's been a couple of issues along the way:

1. I'm not sure if it's possible to write a single test that would test loading config from both windows and linux and that would work from both windows and linux. So I guess we'll need to write separate tests for other platforms down the line? 
2. I couldn't think of a way to test for specific errors. Rather, I'm not sure how to properly assert them when they happen. I can *make* them happen with a corrupt JSON file or an invalid filepath, but then the test simply fails. Need advice.
3. I tried to keep it DRY and write a sub-function to run the test twice instead of copy-pasting the same lines of code, but couldn't make it work. Any suggestions on syntax/structure?