### PR TITLE
fix: update linters and gomod version

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  go: '1.20'
+  go: "1.20"
   concurrency: 4
   timeout: 2m
   issues-exit-code: 1
@@ -12,14 +12,12 @@ run:
   skip-files: [".*_test.go$"]
   tests: true # whether to include test files
 
-
 output:
   format: colored-line-number
   print-issued-lines: false
   print-linter-name: true
   unique-by-line: true
   sort-results: true
-
 
 linters-settings:
   cyclop:
@@ -41,8 +39,8 @@ linters-settings:
     check-type-assertions: true
     check-blank: true
     exclude-functions:
-    - encoding/json.Marshal
-    - encoding/json.MarshalIndent
+      - encoding/json.Marshal
+      - encoding/json.MarshalIndent
 
   errchkjson:
     check-error-free-encoding: true
@@ -50,15 +48,15 @@ linters-settings:
 
   exhaustruct:
     exclude:
-      - '.*Config$'
-      - '.*Settings$'
+      - ".*Config$"
+      - ".*Settings$"
 
   funlen:
     lines: 100
     statements: 70
 
   gocognit:
-    min-complexity: 30 # default: 30     
+    min-complexity: 30 # default: 30
 
   # might need more well defined config after we reenable it
   gocritic:
@@ -69,15 +67,19 @@ linters-settings:
       - experimental
       - opinionated
 
+  gomnd:
+    ignored-functions:
+      - "os.FileMode"
+
   govet:
     check-shadowing: true
     enable-all: true
     disable:
       - fieldalignment
       - nilness
-        
+
   lll:
-    line-length: 200 # default: 120 
+    line-length: 200 # default: 120
 
   nlreturn:
     block-size: 3
@@ -141,124 +143,132 @@ linters-settings:
       - db *gorm.DB
       - tx *gorm.DB
 
-
 linters:
   # enable-all: true
   # disable-all: true
   enable:
     # enabled by default, should not be overridden in custom configs
-    - deadcode          # finds unused code
-    - errcheck          # checks for unchecked errors
-    - gosimple          # tells where code can be simplified
-    - govet             # examines Go source code and reports suspicious constructs
-    - ineffassign       # detects ineffectual assignments
-    - staticcheck       # a huge linter finding many bugs
-    - structcheck       # finds unused struct fields
-    - typecheck         # parses and type-checks Go code
-    - unused            # warns on unused types/functions/etc
-    - varcheck          # finds unused global variables and constants
-
+    - errcheck # checks for unchecked errors
+    - gosimple # tells where code can be simplified
+    - govet # examines Go source code and reports suspicious constructs
+    - ineffassign # detects ineffectual assignments
+    - staticcheck # a huge linter finding many bugs
+    - typecheck # parses and type-checks Go code
+    - unused # warns on unused types/functions/etc
 
     # essential linters that should not be disabled in custom configs
-      # configurable
-    - asasalint         # makes sure you don't pass `[]any` as `any`
-    - bidichk           # checks for invisible unicode characters
-    - dogsled           # finds assignments with too many blank identifiers, e.g. x, _, _ := f()
-    - dupl              # detects code duplication
-    - errchkjson        # checks types passed to json encoders
-    - exhaustive        # checks exhaustiveness of enum switch statements
-    - forbidigo         # forbids some function calls, configurable, by default forbids fmt.Print
-    - gofumpt           # a stricter gofmt
-    - goimports         # checks imports order
-    - gosec             # checks for security issues
-    - ifshort           # detects if statements which could be shorter
-    - maintidx          # measures the maintainability index of each function
-    - makezero          # finds slice declarations with non-zero initial length
-    - misspell          # finds commonly misspelled English words in comments
-    - nakedret          # finds naked returns in long functions 
-    - nilnil            # checks that there is no simultaneous return of nil error and an invalid value
-    - nolintlint        # reports bad nolint directives
-    - nonamedreturns    # warns on named returns
-    - paralleltest      # detects missing usage of t.Parallel() method in tests
-    - prealloc          # finds slice declarations that could potentially be pre-allocated
-    - predeclared       # finds vars with disallowed names
-    - revive            # replaces golint, very configurable
-    - rowserrcheck      # checks whether Err of rows is checked successfully
-    - stylecheck        # another replacement for golint
-    - tenv              # detects using os.Setenv instead of t.Setenv since go 1.17
-    - thelper           # detects golang test helpers without t.Helper() call and checks their consistency
-    - unparam           # reports unused function parameters
-    - whitespace        # checks for unnecessary newlines at the start and end of code blocks
+    # configurable
+    - asasalint # makes sure you don't pass `[]any` as `any`
+    - bidichk # checks for invisible unicode characters
+    - dogsled # finds assignments with too many blank identifiers, e.g. x, _, _ := f()
+    - dupl # detects code duplication
+    - dupword #checks for duplicate words in the source code
+    - errchkjson # checks types passed to json encoders
+    - exhaustive # checks exhaustiveness of enum switch statements
+    - forbidigo # forbids some function calls, configurable, by default forbids fmt.Print
+    - gofumpt # a stricter gofmt
+    - gocritic # a huge and opinionated but useful linter
+    - goimports # checks imports order
+    - gosec # checks for security issues
+    - interfacebloat # checks the number of methods inside an interface
+    - loggercheck # checks key value pairs for common logger libraries
+    - maintidx # measures the maintainability index of each function
+    - makezero # finds slice declarations with non-zero initial length
+    - misspell # finds commonly misspelled English words in comments
+    - musttag # enforces field tags in (un)marshaled structs
+    - nakedret # finds naked returns in long functions
+    - nilnil # checks that there is no simultaneous return of nil error and an invalid value
+    - nolintlint # reports bad nolint directives
+    - nonamedreturns # warns on named returns
+    - paralleltest # detects missing usage of t.Parallel() method in tests
+    - prealloc # finds slice declarations that could potentially be pre-allocated
+    - predeclared # finds vars with disallowed names
+    - reassign # checks that package variables are not reassigned
+    - revive # replaces golint, very configurable
+    - rowserrcheck # checks whether Err of rows is checked successfully
+    - stylecheck # another replacement for golint
+    # - tagalign # check that struct tags are well aligned; since v1.53
+    - tenv # detects using os.Setenv instead of t.Setenv since go 1.17
+    - thelper # detects golang test helpers without t.Helper() call and checks their consistency
+    - unparam # reports unused function parameters
+    - usestdlibvars # detects the possibility to use variables/constants from stdlib
+    - whitespace # checks for unnecessary newlines at the start and end of code blocks
 
-      # non-configurable
-    - asciicheck        # checks that your code does not contain non-ASCII identifiers
-    - bodyclose         # checks whether HTTP response body is closed successfully
-    - containedctx      # detects structs with context.Context field
-    - contextcheck      # checks if you use a non-inherited context
-    - durationcheck     # makes sure you don't multiply two instances of time.Duration
-    - errname           # checks that sentinel errors are prefixed with the Err and error types are suffixed with the Error 
-    - execinquery       # checks where you could use db.Exec instead of db.Query
-    - exportloopref     # checks for pointers to enclosing loop variables
-    - goprintffuncname  # checks that printf-like functions are named with `f` at the end
-    - nilerr            # warns when you do `if err != nil { return nil }`
-    - noctx             # warns when you send an http request without context
-    - sqlclosecheck     # checks that sql.Rows and sql.Stmt are closed
-    - tparallel         # detects inappropriate usage of t.Parallel() method
-    - unconvert         # warns on unnecessary type conversions
-    - wastedassign      # finds unused (re)assignments
-
+    # non-configurable
+    - asciicheck # checks that your code does not contain non-ASCII identifiers
+    - bodyclose # checks whether HTTP response body is closed successfully
+    - containedctx # detects structs with context.Context field
+    - contextcheck # checks if you use a non-inherited context
+    - durationcheck # makes sure you don't multiply two instances of time.Duration
+    - errname # checks that sentinel errors are prefixed with the Err and error types are suffixed with the Error
+    - execinquery # checks where you could use db.Exec instead of db.Query
+    - exportloopref # checks for pointers to enclosing loop variables
+    - gocheckcompilerdirectives # Checks that go compiler directive comments (//go:) are valid
+    - goprintffuncname # checks that printf-like functions are named with `f` at the end
+    - nilerr # warns when you do `if err != nil { return nil }`
+    - noctx # warns when you send an http request without context
+    - sqlclosecheck # checks that sql.Rows and sql.Stmt are closed
+    - tparallel # detects inappropriate usage of t.Parallel() method
+    - unconvert # warns on unnecessary type conversions
+    - wastedassign # finds unused (re)assignments
+    # - zerologlint # detects the wrong usage of zerolog that a user forgets to dispatch with Send or Msg; since v1.53
 
     # these can be disabled in custom configs if there's a real need for that
-      # configurable
-    - cyclop            # checks cyclomatic complexity
-    - errorlint         # makes sure you wrap errors correctly
-    - funlen            # enforces a limit on function length
-    - gocognit          # enforces a limit on function complexity
-    - goconst           # replace repeated strings with a constant
-    - gomnd             # detects magic numbers
-    - ireturn           # disallows returing interfaces ("accept interfaces, return concrete types")
-    - lll               # warns on long lines
-    - nestif            # warns on many nested ifs
-    - promlinter        # check prometheus metrics naming via promlint
+    # configurable
+    - cyclop # checks cyclomatic complexity
+    - errorlint # makes sure you wrap errors correctly
+    - funlen # enforces a limit on function length
+    - gocognit # enforces a limit on function complexity
+    - goconst # replace repeated strings with a constant
+    - gomnd # detects magic numbers
+    # - gosmopolitan # reports some anti-patterns; since v1.53
+    - ireturn # disallows returing interfaces ("accept interfaces, return concrete types")
+    - lll # warns on long lines
+    - nestif # warns on many nested ifs
+    - promlinter # check prometheus metrics naming via promlint
 
-      # non-configurable
-    - gochecknoinits    # tells you not to use init() functions
+    # non-configurable
+    - gochecknoinits # tells you not to use init() functions
     - nosprintfhostport # warns when you build a url with sprintf
-    - nosnakecase       # forbids snake case in variables; may false trigger on stuff like `unix.O_RDONLY`
 
   disable:
     # temporarily
-    - gocritic          # a huge and opinionated but useful linter; panics on generics, will enable it after it's fixed
-    - gci               # controls package import order. temporarily doesn't work on win
-
+    - gci # controls package import order. temporarily doesn't work on win
     # deprecated
-    - golint            # deprecated, replaced with revive
-    - interfacer        # deprecated
-    - maligned          # deprecated, replaced with govet 'fieldalignment'
-    - scopelint         # deprecated, replaced with exportloopref
+    - golint # deprecated, replaced with revive
+    - interfacer # deprecated
+    - maligned # deprecated, replaced with govet 'fieldalignment'
+    - scopelint # deprecated, replaced with exportloopref
+    - deadcode # finds unused code, replaced with 'unused'
+    - structcheck # finds unused struct fields, replaced with 'unused'
+    - ifshort # detects if statements which could be shorter
+    - nosnakecase # forbids snake case in variables; may false trigger on stuff like `unix.O_RDONLY`
+    - varcheck # finds unused global variables and constants, replaced with 'unused'
+    - exhaustivestruct # deprecated, replaced with exhaustruct
 
     # duplicates
-    - exhaustivestruct  # deprecated, we use a fork of it separate from golangcilint
-    - exhaustruct       # checks if all the fields of a struct were initialized; we use a fork of it separately
-    - forcetypeassert   # warns on unchecked type asserts; duplicates errcheck.check-type-assertions behaviour
-    - gocyclo           # same as cyclop and revive has cyclo check as well
-    - gofmt             # superseded by gofumpt
+    - forcetypeassert # warns on unchecked type asserts; duplicates errcheck.check-type-assertions behaviour
+    - gocyclo # same as cyclop and revive has cyclo check as well
+    - gofmt # superseded by gofumpt
 
     # not needed or annoying
-    - decorder          # checks the order and number of declaration; annoying 
-    - depguard          # creates a whitelist/blacklist of packages that can be imported; we don't have these lists (yet)
-    - gochecknoglobals  # tells you not to use globals; we need them sometimes
-    - godot             # checks that comments end with a period; annoying
-    - godox             # checks for TODO and similar stuff; annoying
-    - goerr113          # makes you use static errors; questionable and annoying
-    - goheader          # we don't use license headers
-    - gomoddirectives   # don't really need to ban go.mod directives for now
-    - gomodguard        # like depguard, but more flexible; don't need it for now
-    - grouper           # analyzes import/type groups; not sure if we need it
-    - importas          # enforces import aliasing rules; requires configuration, not sure if needed
-    - nlreturn          # requires a newline before returns; annoying
-    - tagliatelle       # enforce snake/kebab/etc rules on struct tags; needs config, not sure if needed
-    - testpackage       # makes you use a separate *_test package for tests; complicates testing unexported stuff
-    - varnamelen        # reports variables with names too short for their scope; annoying
-    - wsl               # forces to use empty lines where appropriate; very annoying
-    - wrapcheck         # checks whether the errors are wrapped; too annoying
+    - decorder # checks the order and number of declaration; annoying
+    - depguard # creates a whitelist/blacklist of packages that can be imported; we don't have these lists (yet)
+    - exhaustruct # checks if all the fields of a struct were initialized
+    - ginkgolinter # enforces standards of using ginkgo and gomega; we're not using those
+    - gochecknoglobals # tells you not to use globals; we need them sometimes
+    - godot # checks that comments end with a period; annoying
+    - godox # checks for TODO and similar stuff; annoying
+    - goerr113 # makes you use static errors; questionable and annoying
+    - goheader # we don't use license headers
+    - gomoddirectives # don't really need to ban go.mod directives for now
+    - gomodguard # like depguard, but more flexible; don't need it for now
+    - grouper # analyzes import/type groups; not sure if we need it
+    - importas # enforces import aliasing rules; requires configuration, not sure if needed
+    - nlreturn # requires a newline before returns; annoying
+    - tagliatelle # enforce snake/kebab/etc rules on struct tags; needs config, not sure if needed
+    - testableexamples # linter checks if examples are testable ; not needed
+    - testpackage # makes you use a separate *_test package for tests; complicates testing unexported stuff
+    - varnamelen # reports variables with names too short for their scope; annoying
+    - wrapcheck # checks whether the errors are wrapped; too annoying
+    - wsl # forces to use empty lines where appropriate; very annoying

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module anio
 
-go 1.19
+go 1.20
 
 require (
 	github.com/mattn/go-colorable v0.1.13 // indirect


### PR DESCRIPTION
Golangci-lint has seen a few major updates recently, so there are some linter changes